### PR TITLE
Fix Resources$NotFoundException in PagerIndicator

### DIFF
--- a/library/src/main/java/com/hkm/slider/Indicators/PagerIndicator.java
+++ b/library/src/main/java/com/hkm/slider/Indicators/PagerIndicator.java
@@ -3,11 +3,11 @@ package com.hkm.slider.Indicators;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.database.DataSetObserver;
-import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.LayerDrawable;
 import android.graphics.drawable.ShapeDrawable;
+import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
 import android.support.v4.content.ContextCompat;
@@ -18,8 +18,8 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 
 import com.hkm.slider.R;
-import com.hkm.slider.Tricks.InfinitePagerAdapter;
 import com.hkm.slider.SliderAdapter;
+import com.hkm.slider.Tricks.InfinitePagerAdapter;
 import com.hkm.slider.Tricks.ViewPagerEx;
 
 import java.util.ArrayList;
@@ -145,8 +145,10 @@ public class PagerIndicator extends LinearLayout implements ViewPagerEx.OnPageCh
         mUserSetUnSelectedIndicatorResId = attributes.getResourceId(R.styleable.PagerIndicator_unselected_drawable,
                 0);
 
-        mDefaultSelectedColor = attributes.getColor(R.styleable.PagerIndicator_selected_color, Color.rgb(70, 70, 70));
-        mDefaultUnSelectedColor = attributes.getColor(R.styleable.PagerIndicator_unselected_color, Color.argb(33, 148, 148, 148));
+        mDefaultSelectedColor = attributes.getColor(R.styleable.PagerIndicator_selected_color,
+                ContextCompat.getColor(mContext, R.color.default_nsl_light));
+        mDefaultUnSelectedColor = attributes.getColor(R.styleable.PagerIndicator_unselected_color,
+                ContextCompat.getColor(mContext, R.color.default_nsl_dark));
 
         mDefaultSelectedWidth = attributes.getDimension(R.styleable.PagerIndicator_selected_width, (int) pxFromDp(6));
         mDefaultSelectedHeight = attributes.getDimensionPixelSize(R.styleable.PagerIndicator_selected_height, (int) pxFromDp(6));
@@ -277,27 +279,29 @@ public class PagerIndicator extends LinearLayout implements ViewPagerEx.OnPageCh
      * if you are using the default indicator , this method will help you to set the selected status and
      * the unselected status color.
      *
+     * @param selectedColor   color in packet int
+     * @param unselectedColor color in packed int
+     */
+    public void setDefaultIndicatorColor(@ColorInt final int selectedColor, @ColorInt  final int unselectedColor) {
+        if (mUserSetSelectedIndicatorResId == 0) {
+            mSelectedGradientDrawable.setColor(selectedColor);
+        }
+        if (mUserSetUnSelectedIndicatorResId == 0) {
+            mUnSelectedGradientDrawable.setColor(unselectedColor);
+        }
+        resetDrawable();
+    }
+
+    /**
+     * if you are using the default indicator , this method will help you to set the selected status and
+     * the unselected status color.
+     *
      * @param selectedColor   color in resource id
      * @param unselectedColor color in resource id
      */
-    public void setDefaultIndicatorColor(@ColorRes final int selectedColor, @ColorRes final int unselectedColor) {
-        try {
-            if (mUserSetSelectedIndicatorResId == 0) {
-                //  final int a = mContext.getResources().getColor(selectedColor);
-                final int a = ContextCompat.getColor(mContext, selectedColor);
-                mSelectedGradientDrawable.setColor(a);
-            }
-            if (mUserSetUnSelectedIndicatorResId == 0) {
-                //   final int u = mContext.getResources().getColor(unselectedColor);
-                final int u = ContextCompat.getColor(mContext, unselectedColor);
-                mUnSelectedGradientDrawable.setColor(u);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            mUnSelectedGradientDrawable.setColor(ContextCompat.getColor(mContext, R.color.default_nsl_dark));
-            mSelectedGradientDrawable.setColor(ContextCompat.getColor(mContext, R.color.default_nsl_light));
-        }
-        resetDrawable();
+    public void setDefaultIndicatorColorRes(@ColorRes final int selectedColor, @ColorRes final int unselectedColor) {
+        setDefaultIndicatorColor(ContextCompat.getColor(mContext, selectedColor),
+                ContextCompat.getColor(mContext, unselectedColor));
     }
 
     public enum Unit {

--- a/weblnslider/src/main/java/com/hkm/loyalns/demos/BigScreenDL.java
+++ b/weblnslider/src/main/java/com/hkm/loyalns/demos/BigScreenDL.java
@@ -45,7 +45,7 @@ public class BigScreenDL extends AppCompatActivity implements BaseSliderView.OnS
         mDemoSlider.addOnPageChangeListener(this);
         mDemoSlider.setOffscreenPageLimit(3);
         mDemoSlider.setSliderTransformDuration(400, new LinearOutSlowInInterpolator());
-        mDemoSlider.getPagerIndicator().setDefaultIndicatorColor(R.color.red_pink_26, R.color.red_pink_27);
+        mDemoSlider.getPagerIndicator().setDefaultIndicatorColorRes(R.color.red_pink_26, R.color.red_pink_27);
         mDemoSlider.setNumLayout(new NumZero(this));
         mDemoSlider.presentation(SliderLayout.PresentationConfig.Numbers);
         ListView l = (ListView) findViewById(R.id.transformers);

--- a/weblnslider/src/main/java/com/hkm/loyalns/demos/BigScreenDemo.java
+++ b/weblnslider/src/main/java/com/hkm/loyalns/demos/BigScreenDemo.java
@@ -79,7 +79,7 @@ public class BigScreenDemo extends AppCompatActivity implements BaseSliderView.O
         mDemoSlider.addOnPageChangeListener(this);
         mDemoSlider.setOffscreenPageLimit(3);
         mDemoSlider.setSliderTransformDuration(400, new LinearOutSlowInInterpolator());
-        mDemoSlider.getPagerIndicator().setDefaultIndicatorColor(R.color.red_pink_26, R.color.red_pink_27);
+        mDemoSlider.getPagerIndicator().setDefaultIndicatorColorRes(R.color.red_pink_26, R.color.red_pink_27);
         mDemoSlider.setNumLayout(new NumZero(this));
         mDemoSlider.presentation(SliderLayout.PresentationConfig.Numbers);
         ListView l = (ListView) findViewById(R.id.transformers);

--- a/weblnslider/src/main/java/com/hkm/loyalns/demos/ExampleClassic.java
+++ b/weblnslider/src/main/java/com/hkm/loyalns/demos/ExampleClassic.java
@@ -44,7 +44,7 @@ public class ExampleClassic extends BaseApp {
         mDemoSlider.addOnPageChangeListener(this);
         mDemoSlider.setOffscreenPageLimit(3);
         mDemoSlider.setSliderTransformDuration(400, new LinearOutSlowInInterpolator());
-        mDemoSlider.getPagerIndicator().setDefaultIndicatorColor(R.color.red_pink_26, R.color.red_pink_27);
+        mDemoSlider.getPagerIndicator().setDefaultIndicatorColorRes(R.color.red_pink_26, R.color.red_pink_27);
         final NumZero n = new NumZero(this);
         mDemoSlider.setNumLayout(n);
         mDemoSlider.presentation(SliderLayout.PresentationConfig.Numbers);

--- a/weblnslider/src/main/java/com/hkm/loyalns/demos/MultSections.java
+++ b/weblnslider/src/main/java/com/hkm/loyalns/demos/MultSections.java
@@ -44,7 +44,7 @@ public class MultSections extends BaseApp {
         mDemoSlider.addOnPageChangeListener(this);
         mDemoSlider.setOffscreenPageLimit(3);
         mDemoSlider.setSliderTransformDuration(400, new LinearOutSlowInInterpolator());
-        mDemoSlider.getPagerIndicator().setDefaultIndicatorColor(R.color.red_pink_26, R.color.red_pink_27);
+        mDemoSlider.getPagerIndicator().setDefaultIndicatorColorRes(R.color.red_pink_26, R.color.red_pink_27);
         final NumZero n = new NumZero(this);
         mDemoSlider.setNumLayout(n);
         mDemoSlider.presentation(SliderLayout.PresentationConfig.Numbers);

--- a/weblnslider/src/main/java/com/hkm/loyalns/demos/SliderAdjust1.java
+++ b/weblnslider/src/main/java/com/hkm/loyalns/demos/SliderAdjust1.java
@@ -10,7 +10,6 @@ import com.hkm.slider.SliderLayout;
 import com.hkm.slider.SliderTypes.AdjustableSlide;
 import com.hkm.slider.SliderTypes.BaseSliderView;
 import com.hkm.slider.TransformerL;
-import com.hkm.slider.Tricks.ViewPagerEx;
 
 import java.util.ArrayList;
 
@@ -27,7 +26,7 @@ public class SliderAdjust1 extends BaseApp {
         mDemoSlider.addOnPageChangeListener(this);
         mDemoSlider.setOffscreenPageLimit(3);
         mDemoSlider.setSliderTransformDuration(400, new LinearOutSlowInInterpolator());
-        mDemoSlider.getPagerIndicator().setDefaultIndicatorColor(R.color.red_pink_26, R.color.red_pink_27);
+        mDemoSlider.getPagerIndicator().setDefaultIndicatorColorRes(R.color.red_pink_26, R.color.red_pink_27);
         mDemoSlider.setAutoAdjustImageByHeight();
         String[] urls = {
                 //   "http://pcdn.500px.net/35939982/127d53ceac436e2e17a11ea42bb2cd7719b9f1e1/4.jpg",

--- a/weblnslider/src/main/java/com/hkm/loyalns/demos/SliderAdjust2.java
+++ b/weblnslider/src/main/java/com/hkm/loyalns/demos/SliderAdjust2.java
@@ -1,7 +1,6 @@
 package com.hkm.loyalns.demos;
 
 import android.support.v4.view.animation.LinearOutSlowInInterpolator;
-import android.view.View;
 
 import com.hkm.loyalns.R;
 import com.hkm.loyalns.mod.BaseApp;
@@ -27,7 +26,7 @@ public class SliderAdjust2 extends BaseApp {
         mDemoSlider.addOnPageChangeListener(this);
         mDemoSlider.setOffscreenPageLimit(3);
         mDemoSlider.setSliderTransformDuration(400, new LinearOutSlowInInterpolator());
-        mDemoSlider.getPagerIndicator().setDefaultIndicatorColor(R.color.red_pink_26, R.color.red_pink_27);
+        mDemoSlider.getPagerIndicator().setDefaultIndicatorColorRes(R.color.red_pink_26, R.color.red_pink_27);
         mDemoSlider.setDisablePageIndicator();
         mDemoSlider.setAutoAdjustImageByHeight();
         String[] urls = {


### PR DESCRIPTION
This renames the old setDefaultIndicatorColor to a new created method called setDefaultIndicatorColorRes, which receives color resources and convert it to a packed color int, passing it to the packed color method. 

Fixes #51 
